### PR TITLE
chore(release): v3.1.3 — lgrep pool wedge fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
-## 2026-05-27 (v3.1.2)\n\n### Changed\n- refresh repo improvement prep
+## 2026-06-10 (v3.1.3)
+
+### Fixed
+
+- **lgrep pool wedge from abandoned index** — the shared MCP daemon no longer permanently wedges its bounded worker pool when a search-triggered auto-index is abandoned at the 8s tool timeout. Cooperative cancellation is now threaded through every blocking seam (`index_all` → `index_file` → `embed_documents` → `_embed_batch_with_retry`), the exponential-backoff retry sleep is interruptible via `cancel_event.wait(timeout=delay)` instead of `time.sleep`, and a hard wall-clock backstop (`LGREP_INDEX_MAX_WALL_S`, default 60s) guarantees `index_all` aborts regardless of where it blocks. Abandoned `index_all` jobs now reach a terminal state and release their worker (verified in production: pokeedge index_all jobs cancel in ~6s via `cancel_event` rather than wedging the pool). `_check_staleness` is additionally bounded by `LGREP_STALENESS_DEADLINE_S` (default 4.0s) so drift detection cannot consume the 8s search budget. `OperationCancelled` moved to `lgrep/exceptions.py` (re-exported from `indexing.py` for backward compatibility).
+
+### Changed
+
+- (v3.1.2) refresh repo improvement prep
 
 ## 2026-05-22 (v3.1.1)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lgrep"
-version = "3.1.0"
+version = "3.1.3"
 description = "Dual-engine code intelligence MCP server: semantic search (Voyage Code 3 + LanceDB) and symbol intelligence (tree-sitter AST parsing)"
 readme = "README.md"
 license = "MIT"

--- a/src/lgrep/__init__.py
+++ b/src/lgrep/__init__.py
@@ -7,4 +7,4 @@ Symbol engine: tree-sitter AST parsing for exact symbol lookup, file outlines,
 and structural code navigation across 165+ languages.
 """
 
-__version__ = "3.1.0"
+__version__ = "3.1.3"


### PR DESCRIPTION
Cuts the v3.1.3 release for the lgrep pool wedge fix (PR #3, merged as ac393ee).

The auto-release workflow ran on that merge but skipped cutting a release because the squash-merge commit title (`Fix lgrep pool wedge from abandoned index (#3)`) is not a conventional commit, so the bump logic matched no `fix:`/`feat:` prefix.

This PR:
- bumps `src/lgrep/__init__.py` and `pyproject.toml` 3.1.0 → 3.1.3 (aligns version string to the next tag after v3.1.2; `test_version_matches_pyproject` passes)
- adds the `## 2026-06-10 (v3.1.3)` CHANGELOG entry documenting the cooperative-cancellation fix
- fixes the malformed literal-\n v3.1.2 CHANGELOG line

After merge, the GitHub release v3.1.3 will be created with notes.